### PR TITLE
lib/topic.js: better assert message

### DIFF
--- a/lib/topic.js
+++ b/lib/topic.js
@@ -1,6 +1,7 @@
 // topic: utility code for topics
 
 var assert = require('assert');
+var format = require('util').format;
 
 exports.valid = valid;
 exports.check = check;
@@ -28,7 +29,14 @@ function check(pattern) {
     pattern = '';
   }
 
-  assert(valid(pattern), 'topic patterns must be .-separated alphanumeric words');
+  if (!valid(pattern)) {
+    // pattern can be a non-string!
+    assert(false, format(
+      'Invalid topic %j. ' +
+        'Topic patterns must be .-separated alphanumeric words',
+      pattern
+    ));
+  }
 
   return pattern;
 }


### PR DESCRIPTION
Modified the message reported for an invalid topic name to include the invalid
value. This should help troubleshooting errors that are difficult to reproduce
on a developer's machine.

This is a part of my work on SLN-495. I'll need to release 0.0.6 after this change is merged.

@sam-github: please review.
