### PR TITLE
Detect and fail on invalid multiple instantiation

### DIFF
--- a/lib/adapters/native/broker.js
+++ b/lib/adapters/native/broker.js
@@ -14,15 +14,11 @@ var VERSION = require('../../../package.json').version;
 
 // Only initialize a broker in the master
 if (cluster.isMaster) {
-  assert(!cluster._strongMqVersion,
-      'Multiple versions of strong-mq are being initialized, see README for more information'
-      );
+  assert(!cluster._strongMqNative, 'Multiple instantiation detected!');
 
   exports._init = _init;
   exports._final = _final;
   exports._init();
-
-  cluster._strongMqVersion = VERSION;
 }
 
 

--- a/lib/adapters/native/index.js
+++ b/lib/adapters/native/index.js
@@ -1,1 +1,17 @@
+var assert = require('assert');
+var cluster = require('cluster');
+var VERSION = require('../../../package.json').version;
+
+if(cluster._strongMqNative) {
+  assert(
+    cluster._strongMqNative.VERSION === VERSION,
+    'Multiple versions of strong-mq are being initialized.\n' +
+    'This version ' + VERSION + ' is incompatible with already initialized\n' +
+    'version ' + cluster._strongMqNative.VERSION + '.\n'
+  );
+  module.exports = cluster._strongMqNative;
+  return;
+}
 module.exports = require('./connection');
+module.exports.VERSION = VERSION;
+cluster._strongMqNative = module.exports;


### PR DESCRIPTION
Using peerDependencies should prevent this situation, but we should fail
hard and early on invalid usage.

/to @Schoonology @bajtos See strong-cluster-control#16
